### PR TITLE
init_disassemble_info() signature changes causes compile failures

### DIFF
--- a/tools/perf/util/annotate.c
+++ b/tools/perf/util/annotate.c
@@ -1685,6 +1685,18 @@ fallback:
 #include <bfd.h>
 #include <dis-asm.h>
 
+static int fprintf_styled(void *, enum disassembler_style, const char* fmt, ...)
+{
+  va_list args;
+  int r;
+
+  va_start(args, fmt);
+  r = vprintf(fmt, args);
+  va_end(args);
+
+  return r;
+}
+
 static int symbol__disassemble_bpf(struct symbol *sym,
 				   struct annotate_args *args)
 {
@@ -1727,7 +1739,8 @@ static int symbol__disassemble_bpf(struct symbol *sym,
 		goto out;
 	}
 	init_disassemble_info(&info, s,
-			      (fprintf_ftype) fprintf);
+			      (fprintf_ftype) fprintf,
+			      fprintf_styled);
 
 	info.arch = bfd_get_arch(bfdf);
 	info.mach = bfd_get_mach(bfdf);


### PR DESCRIPTION
Hi,

binutils changed the signature of init_disassemble_info(), which now causes perf and bpftool to fail to compile (e.g. on debian unstable).

Relevant binutils commit: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=60a3da00bd5407f07d64dff82a4dae98230dfaac

util/annotate.c: In function ‘symbol__disassemble_bpf’: util/annotate.c:1765:9: error: too few arguments to function ‘init_disassemble_info’
 1765 |         init_disassemble_info(&info, s,
      |         ^~~~~~~~~~~~~~~~~~~~~
In file included from util/annotate.c:1718:
/usr/include/dis-asm.h:472:13: note: declared here
  472 | extern void init_disassemble_info (struct disassemble_info *dinfo, void *stream,
      |             ^~~~~~~~~~~~~~~~~~~~~

with equivalent failures in

tools/bpf/bpf_jit_disasm.c
tools/bpf/bpftool/jit_disasm.c

The fix is easy enough, add a wrapper around fprintf() that conforms to the new signature.

However I assume the necessary feature test and wrapper should only be added once? I don't know the kernel stuff well enough to choose the right structure here.

Attached is my local fix for perf. Obviously would need work to be a real solution.

Greetings,

Andres Freund