### PR TITLE
hx280enc_vc8000e: fix misplaced #endif

### DIFF
--- a/drivers/mxc/hantro_vc8000e/hx280enc_vc8000e.c
+++ b/drivers/mxc/hantro_vc8000e/hx280enc_vc8000e.c
@@ -703,7 +703,6 @@ static long hantroenc_ioctl32(struct file *filp, unsigned int cmd, unsigned long
 	if (err) \
 		return err; \
 }
-#endif
 
 union {
 	unsigned long kux;
@@ -793,6 +792,7 @@ union {
 	}
 	return 0;
 }
+#endif
 
 /* VFS methods */
 static struct file_operations hantroenc_fops = {


### PR DESCRIPTION
With CONFIG_COMPAT not set the code fails to compile. Move the
closing #endif to the end of the function which should only be
compiled if CONFIG_COMPAT is set.