### PR TITLE
ARM: dts: imx6sx: fix, remove conflict marker

### DIFF
--- a/arch/arm/boot/dts/imx6sx.dtsi
+++ b/arch/arm/boot/dts/imx6sx.dtsi
@@ -940,7 +940,6 @@
 				reg = <0x020e4000 0x4000>;
 			};
 
-<<<<<<< HEAD
 			ldb: ldb@20e0014 {
 				#address-cells = <1>;
 				#size-cells = <0>;


### PR DESCRIPTION
My stable patches don't build for imx_v7_defconfig. Sorry.