### PR TITLE
Fslc 6.1 2.2.x imx fixes

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mm.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mm.dtsi
@@ -1285,40 +1285,6 @@
 				ports = <&lcdif_disp0>;
 			};
 
-			mipi_csi: mipi-csi@32e30000 {
-				compatible = "fsl,imx8mm-mipi-csi2";
-				reg = <0x32e30000 0x1000>;
-				interrupts = <GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>;
-				assigned-clocks = <&clk IMX8MM_CLK_CSI1_CORE>;
-				assigned-clock-parents = <&clk IMX8MM_SYS_PLL2_1000M>;
-
-				clock-frequency = <333000000>;
-				clocks = <&clk IMX8MM_CLK_DISP_APB_ROOT>,
-					 <&clk IMX8MM_CLK_CSI1_ROOT>,
-					 <&clk IMX8MM_CLK_CSI1_PHY_REF>,
-					 <&clk IMX8MM_CLK_DISP_AXI_ROOT>;
-				clock-names = "pclk", "wrap", "phy", "axi";
-				power-domains = <&disp_blk_ctrl IMX8MM_DISPBLK_PD_MIPI_CSI>;
-				status = "disabled";
-
-				ports {
-					#address-cells = <1>;
-					#size-cells = <0>;
-
-					port@0 {
-						reg = <0>;
-					};
-
-					port@1 {
-						reg = <1>;
-
-						imx8mm_mipi_csi_out: endpoint {
-							remote-endpoint = <&csi1_bridge>;
-						};
-					};
-				};
-			};
-
 			usbotg1: usb@32e40000 {
 				compatible = "fsl,imx8mm-usb", "fsl,imx7d-usb";
 				reg = <0x32e40000 0x200>;

--- a/drivers/phy/freescale/phy-fsl-lynx-28g.c
+++ b/drivers/phy/freescale/phy-fsl-lynx-28g.c
@@ -1371,9 +1371,8 @@ static int lynx_28g_probe(struct platform_device *pdev)
 
 	dev_set_drvdata(dev, priv);
 
-	INIT_DELAYED_WORK(&priv->cdr_check, lynx_28g_cdr_lock_check_work);
 	spin_lock_init(&priv->pcc_lock);
-	INIT_DELAYED_WORK(&priv->cdr_check, lynx_28g_cdr_lock_check);
+	INIT_DELAYED_WORK(&priv->cdr_check, lynx_28g_cdr_lock_check_work);
 
 	queue_delayed_work(system_power_efficient_wq, &priv->cdr_check,
 			   msecs_to_jiffies(1000));


### PR DESCRIPTION
For two files the conflict resolve in #650 seems to be not correct:

phy-fsl-lynx-28g.c: commit 1e2010f6
imx8mm.dtsi: commit 453b7992

This prepares the merge of NXP tag lf-6.1.55-2.2.0


