### PR TITLE
arch: arm64: freescale: imx8: fix sdhci clocks

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8-ss-conn.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8-ss-conn.dtsi
@@ -73,9 +73,9 @@ conn_subsys: bus@5b000000 {
 	usdhc1: mmc@5b010000 {
 		interrupts = <GIC_SPI 232 IRQ_TYPE_LEVEL_HIGH>;
 		reg = <0x5b010000 0x10000>;
-		clocks = <&sdhc0_lpcg IMX_LPCG_CLK_4>,
-			 <&sdhc0_lpcg IMX_LPCG_CLK_5>,
-			 <&sdhc0_lpcg IMX_LPCG_CLK_0>;
+ 		clocks = <&sdhc0_lpcg 1>,
+ 			 <&sdhc0_lpcg 2>,
+ 			 <&sdhc0_lpcg 0>;
 		clock-names = "ipg", "ahb", "per";
 		assigned-clocks = <&clk IMX_SC_R_SDHC_0 IMX_SC_PM_CLK_PER>;
 		assigned-clock-rates = <400000000>;
@@ -88,9 +88,9 @@ conn_subsys: bus@5b000000 {
 	usdhc2: mmc@5b020000 {
 		interrupts = <GIC_SPI 233 IRQ_TYPE_LEVEL_HIGH>;
 		reg = <0x5b020000 0x10000>;
-		clocks = <&sdhc1_lpcg IMX_LPCG_CLK_4>,
-			 <&sdhc1_lpcg IMX_LPCG_CLK_5>,
-			 <&sdhc1_lpcg IMX_LPCG_CLK_0>;
+ 		clocks = <&sdhc0_lpcg 1>,
+ 			 <&sdhc0_lpcg 2>,
+ 			 <&sdhc0_lpcg 0>;
 		clock-names = "ipg", "ahb", "per";
 		assigned-clocks = <&clk IMX_SC_R_SDHC_1 IMX_SC_PM_CLK_PER>;
 		assigned-clock-rates = <200000000>;
@@ -103,9 +103,9 @@ conn_subsys: bus@5b000000 {
 	usdhc3: mmc@5b030000 {
 		interrupts = <GIC_SPI 234 IRQ_TYPE_LEVEL_HIGH>;
 		reg = <0x5b030000 0x10000>;
-		clocks = <&sdhc2_lpcg IMX_LPCG_CLK_4>,
-			 <&sdhc2_lpcg IMX_LPCG_CLK_5>,
-			 <&sdhc2_lpcg IMX_LPCG_CLK_0>;
+ 		clocks = <&sdhc0_lpcg 1>,
+ 			 <&sdhc0_lpcg 2>,
+ 			 <&sdhc0_lpcg 0>;
 		clock-names = "ipg", "ahb", "per";
 		assigned-clocks = <&clk IMX_SC_R_SDHC_2 IMX_SC_PM_CLK_PER>;
 		assigned-clock-rates = <200000000>;


### PR DESCRIPTION
During the merge the incompatible clock indices from mainline was mistakenly downstreamed to for imx8. This breaks sdhci interfaces working. Fix clock indices.

Fixes:   92f1bfbbda276 ("Merge tag 'v6.6.28' into 6.6-1.0.x-imx")

https://github.com/Freescale/linux-fslc/issues/666
