### PR TITLE
i2c: imx: Remove unnecessary clock reconfiguration

### DIFF
--- a/drivers/i2c/busses/i2c-imx.c
+++ b/drivers/i2c/busses/i2c-imx.c
@@ -722,10 +722,6 @@ static int i2c_imx_start(struct imx_i2c_struct *i2c_imx, bool atomic)
 	unsigned int temp = 0;
 	int result;
 
-	result = i2c_imx_set_clk(i2c_imx, clk_get_rate(i2c_imx->clk));
-	if (result)
-		return result;
-
 	imx_i2c_write_reg(i2c_imx->ifdr, i2c_imx, IMX_I2C_IFDR);
 	/* Enable I2C controller */
 	imx_i2c_write_reg(i2c_imx->hwdata->i2sr_clr_opcode, i2c_imx, IMX_I2C_I2SR);


### PR DESCRIPTION
The I2C clock is already reconfigured within the clock notifier. This also fixes an ABBA locking deadlock if some other I2C device reconfigures clocks it provides, e.g. tlv320aic32x4 during probe.

Fixes: 0e94d44f44031 ("MLK-20368 i2c-imx: Coverity: fix divide by zero warning")