### PR TITLE
6.6 2.1.x imx

### DIFF
--- a/drivers/mxc/hantro_v4l2/vsi-v4l2-dec.c
+++ b/drivers/mxc/hantro_v4l2/vsi-v4l2-dec.c
@@ -838,7 +838,6 @@ static void vsi_dec_buf_queue(struct vb2_buffer *vb)
 		set_bit(BUF_FLAG_QUEUED, &ctx->srcvbufflag[vb->index]);
 		list_add_tail(&vsibuf->list, &ctx->input_list);
 		ctx->queued_srcnum++;
-		ctx->performance.input_buf_num++;
 	}
 	ret = vsiv4l2_execcmd(ctx, V4L2_DAEMON_VIDIOC_BUF_RDY, vb);
 }
@@ -856,27 +855,16 @@ static int vsi_dec_buf_prepare(struct vb2_buffer *vb)
 static int vsi_dec_start_streaming(struct vb2_queue *q, unsigned int count)
 {
 	struct vsi_v4l2_ctx *ctx = fh_to_ctx(q->drv_priv);
-	struct vb2_queue *vq_peer;
 
-	if (V4L2_TYPE_IS_OUTPUT(q->type)) {
+	if (V4L2_TYPE_IS_OUTPUT(q->type))
 		ctx->out_sequence = 0;
-		vq_peer = &ctx->output_que;
-	} else {
+	else
 		ctx->cap_sequence = 0;
-		vq_peer = &ctx->input_que;
-	}
-
-	if (vb2_is_streaming(vq_peer))
-		ctx->performance.ts_start = ktime_get_raw();
 
 	return 0;
 }
-static void vsi_dec_stop_streaming(struct vb2_queue *q)
+static void vsi_dec_stop_streaming(struct vb2_queue *vq)
 {
-	struct vsi_v4l2_ctx *ctx = fh_to_ctx(q->drv_priv);
-
-	if (V4L2_TYPE_IS_OUTPUT(q->type))
-		vsi_v4l2_reset_performance(ctx);
 }
 
 static void vsi_dec_buf_finish(struct vb2_buffer *vb)
@@ -1214,9 +1202,6 @@ static int v4l2_dec_open(struct file *filp)
 	atomic_set(&ctx->srcframen, 0);
 	atomic_set(&ctx->dstframen, 0);
 	ctx->status = VSI_STATUS_INIT;
-	ctx->tgid = current->tgid;
-	ctx->pid = current->pid;
-	vsi_v4l2_create_dbgfs_file(ctx);
 
 	//dev->vdev->queue = q;
 	//single queue is used for v4l2 default ops such as ioctl, read, write and poll

--- a/drivers/mxc/hantro_v4l2/vsi-v4l2-enc.c
+++ b/drivers/mxc/hantro_v4l2/vsi-v4l2-enc.c
@@ -783,12 +783,10 @@ static void vsi_enc_buf_queue(struct vb2_buffer *vb)
 
 	v4l2_klog(LOGLVL_FLOW, "%s:%d:%d", __func__, vb->type, vb->index);
 	vsibuf = vb_to_vsibuf(vb);
-	if (!binputqueue(vq->type)) {
+	if (!binputqueue(vq->type))
 		list_add_tail(&vsibuf->list, &ctx->output_list);
-	} else {
+	else
 		list_add_tail(&vsibuf->list, &ctx->input_list);
-		ctx->performance.input_buf_num++;
-	}
 	ret = vsiv4l2_execcmd(ctx, V4L2_DAEMON_VIDIOC_BUF_RDY, vb);
 }
 
@@ -808,27 +806,16 @@ static int vsi_enc_buf_prepare(struct vb2_buffer *vb)
 static int vsi_enc_start_streaming(struct vb2_queue *q, unsigned int count)
 {
 	struct vsi_v4l2_ctx *ctx = fh_to_ctx(q->drv_priv);
-	struct vb2_queue *vq_peer;
 
-	if (V4L2_TYPE_IS_OUTPUT(q->type)) {
+	if (V4L2_TYPE_IS_OUTPUT(q->type))
 		ctx->out_sequence = 0;
-		vq_peer = &ctx->output_que;
-	} else {
+	else
 		ctx->cap_sequence = 0;
-		vq_peer = &ctx->input_que;
-	}
-
-	if (vb2_is_streaming(vq_peer))
-		ctx->performance.ts_start = ktime_get_raw();
 
 	return 0;
 }
-static void vsi_enc_stop_streaming(struct vb2_queue *q)
+static void vsi_enc_stop_streaming(struct vb2_queue *vq)
 {
-	struct vsi_v4l2_ctx *ctx = fh_to_ctx(q->drv_priv);
-
-	if (V4L2_TYPE_IS_OUTPUT(q->type))
-		vsi_v4l2_reset_performance(ctx);
 }
 
 static void vsi_enc_buf_finish(struct vb2_buffer *vb)
@@ -1529,9 +1516,6 @@ static int v4l2_enc_open(struct file *filp)
 	atomic_set(&ctx->srcframen, 0);
 	atomic_set(&ctx->dstframen, 0);
 	ctx->status = VSI_STATUS_INIT;
-	ctx->tgid = current->tgid;
-	ctx->pid = current->pid;
-	vsi_v4l2_create_dbgfs_file(ctx);
 
 	return 0;
 

--- a/drivers/mxc/hantro_v4l2/vsi-v4l2-priv.h
+++ b/drivers/mxc/hantro_v4l2/vsi-v4l2-priv.h
@@ -22,7 +22,6 @@
 
 #include <linux/version.h>
 #include <linux/v4l2-controls.h>
-#include <linux/debugfs.h>
 #include <linux/imx_vpu.h>
 #include "vsi-v4l2.h"
 
@@ -250,7 +249,6 @@ struct vsi_v4l2_device {
 	struct video_device *vdec;
 	struct mutex lock;
 	struct mutex irqlock;
-	struct dentry *debugfs;
 };
 
 struct vsi_vpu_buf {
@@ -300,17 +298,6 @@ enum {
 	BUF_FLAG_DONE,			/*buf returned from daemon*/
 	BUF_FLAG_CROPCHANGE,		/*crop area update not sent to app but buffed */
 	BUF_FLAG_TIMESTAMP_INVALID,
-};
-
-struct vsi_vpu_performance_info {
-	ktime_t ts_start;
-	ktime_t ts_last;
-	ktime_t ts_disp_first;
-	ktime_t ts_disp_last;
-	u64 total_time;
-	u64 input_buf_num;
-	u64 processed_buf_num;
-	u64 display_frame_num;
 };
 
 struct vsi_v4l2_ctx {
@@ -363,12 +350,6 @@ struct vsi_v4l2_ctx {
 
 	u32 out_sequence;
 	u32 cap_sequence;
-
-	pid_t tgid;
-	pid_t pid;
-
-	struct vsi_vpu_performance_info performance;
-	struct dentry *debugfs;
 };
 
 struct vsi_v4l2_ctrl_applicable {
@@ -397,8 +378,6 @@ struct video_device *vsi_v4l2_probe_enc(
 void vsi_v4l2_release_enc(struct video_device *venc);
 struct video_device *vsi_v4l2_probe_dec(struct platform_device *pdev, struct vsi_v4l2_device *vpu);
 void vsi_v4l2_release_dec(struct video_device *vdec);
-int vsi_v4l2_create_dbgfs_file(struct vsi_v4l2_ctx *ctx);
-void vsi_v4l2_remove_dbgfs_file(struct vsi_v4l2_ctx *ctx);
 
 u64 vsi_v4l2_getbandwidth(void);
 int vsiv4l2_initdaemon(void);
@@ -448,7 +427,6 @@ void vsi_convertROI(struct vsi_v4l2_ctx *ctx);
 void vsi_convertIPCM(struct vsi_v4l2_ctx *ctx);
 int vsiv4l2_verifycrop(struct v4l2_selection *s);
 void vsi_v4l2_update_ctrlcfg(struct v4l2_ctrl_config *cfg);
-void vsi_v4l2_reset_performance(struct vsi_v4l2_ctx *ctx);
 bool vsi_v4l2_ctrl_is_applicable(struct vsi_v4l2_ctx *ctx, u32 ctrl_id);
 
 static inline int isencoder(struct vsi_v4l2_ctx *ctx)

--- a/drivers/mxc/hantro_v4l2/vsi-v4l2.c
+++ b/drivers/mxc/hantro_v4l2/vsi-v4l2.c
@@ -76,142 +76,6 @@ static const struct attribute_group vsi_v4l2_attr_group = {
 	.attrs = vsi_v4l2_attrs,
 };
 
-#define VSI_V4L2_DEBUGFS_DIR	"vsiv4l2"
-
-static int vsi_v4l2_dbg_instance(struct seq_file *s, void *data)
-{
-	struct vsi_v4l2_ctx *ctx = s->private;
-	struct vsi_vpu_performance_info *info = &ctx->performance;
-	struct vb2_queue *vq;
-	struct v4l2_format format;
-	u64 fps_dec = 0, fps_dsp = 0, fps_sw = 0;
-	u64 timems;
-	u64 latency;
-	u64 temp;
-	char str[128];
-	int num;
-
-	num = scnprintf(str, sizeof(str), "[%s]\n", isdecoder(ctx) ? "Decoder" : "Encoder");
-	if (seq_write(s, str, num))
-		return 0;
-
-	num = scnprintf(str, sizeof(str),
-			"status = %d, error = %d, flags = 0x%lx, tgid = %d, pid = %d\n",
-			ctx->status, ctx->error, ctx->flag, ctx->tgid, ctx->pid);
-	if (seq_write(s, str, num))
-		return 0;
-
-	vq = &ctx->input_que;
-	format.type = vq->type;
-	vsiv4l2_getfmt(ctx, &format);
-	num = scnprintf(str, sizeof(str),
-			"output (%2d, %2d): fmt = %c%c%c%c %d x %d, %d;\n",
-			vb2_is_streaming(vq),
-			vq->num_buffers,
-			format.fmt.pix_mp.pixelformat,
-			format.fmt.pix_mp.pixelformat >> 8,
-			format.fmt.pix_mp.pixelformat >> 16,
-			format.fmt.pix_mp.pixelformat >> 24,
-			format.fmt.pix_mp.width,
-			format.fmt.pix_mp.height,
-			vq->last_buffer_dequeued);
-	if (seq_write(s, str, num))
-		return 0;
-
-	vq = &ctx->output_que;
-	format.type = vq->type;
-	vsiv4l2_getfmt(ctx, &format);
-	num = scnprintf(str, sizeof(str),
-			"capture(%2d, %2d): fmt = %c%c%c%c %d x %d, %d;\n",
-			vb2_is_streaming(vq),
-			vq->num_buffers,
-			format.fmt.pix_mp.pixelformat,
-			format.fmt.pix_mp.pixelformat >> 8,
-			format.fmt.pix_mp.pixelformat >> 16,
-			format.fmt.pix_mp.pixelformat >> 24,
-			format.fmt.pix_mp.width,
-			format.fmt.pix_mp.height,
-			vq->last_buffer_dequeued);
-	if (seq_write(s, str, num))
-		return 0;
-
-	num = scnprintf(str, sizeof(str), "input %llu, process %llu, show %llu\n",
-			info->input_buf_num, info->processed_buf_num, info->display_frame_num);
-	if (seq_write(s, str, num))
-		return 0;
-
-	num = scnprintf(str, sizeof(str), "fps");
-	if (seq_write(s, str, num))
-		return 0;
-
-	temp = MSEC_PER_SEC * info->processed_buf_num;
-	timems = (info->ts_last - info->ts_start) / NSEC_PER_MSEC;
-	fps_dec = DIV_ROUND_CLOSEST(temp, timems);
-	if (info->total_time)
-		fps_sw = DIV_ROUND_CLOSEST(temp, info->total_time / NSEC_PER_MSEC);
-	if (info->display_frame_num > 1) {
-		temp = MSEC_PER_SEC * (info->display_frame_num - 1);
-		timems = (info->ts_disp_last - info->ts_disp_first) / NSEC_PER_MSEC;
-		fps_dsp = DIV_ROUND_CLOSEST(temp, timems);
-	}
-	latency = info->ts_disp_first - info->ts_start;
-
-	num = scnprintf(str, sizeof(str), " actual: %llu;", fps_dec);
-	if (seq_write(s, str, num))
-		return 0;
-	if (fps_dsp) {
-		num = scnprintf(str, sizeof(str), " disp: %llu;", fps_dsp);
-		if (seq_write(s, str, num))
-			return 0;
-	}
-	num = scnprintf(str, sizeof(str), " ideal: %llu;", fps_sw);
-	if (seq_write(s, str, num))
-		return 0;
-	num = scnprintf(str, sizeof(str), " latency(ms): %llu.%06llu\n",
-			latency / NSEC_PER_MSEC, latency % NSEC_PER_MSEC);
-	if (seq_write(s, str, num))
-		return 0;
-
-	return 0;
-}
-
-static int vsi_v4l2_dbg_open(struct inode *inode, struct file *filp)
-{
-	return single_open(filp, vsi_v4l2_dbg_instance, inode->i_private);
-}
-
-static const struct file_operations vsi_v4l2_dbg_fops = {
-	.owner = THIS_MODULE,
-	.open = vsi_v4l2_dbg_open,
-	.release = single_release,
-	.read = seq_read,
-};
-
-int vsi_v4l2_create_dbgfs_file(struct vsi_v4l2_ctx *ctx)
-{
-	char name[64];
-
-	if (!ctx || !ctx->dev || !ctx->dev->debugfs)
-		return -EINVAL;
-
-	scnprintf(name, sizeof(name), "instance.%d", (int)(ctx->ctxid & 0xFFFFFFFF));
-	ctx->debugfs = debugfs_create_file((const char *)name,
-					   VERIFY_OCTAL_PERMISSIONS(0444),
-					   ctx->dev->debugfs,
-					   ctx,
-					   &vsi_v4l2_dbg_fops);
-	return 0;
-}
-
-void vsi_v4l2_remove_dbgfs_file(struct vsi_v4l2_ctx *ctx)
-{
-	if (!ctx || !ctx->debugfs)
-		return;
-
-	debugfs_remove(ctx->debugfs);
-	ctx->debugfs = NULL;
-}
-
 static struct vsi_v4l2_ctx *get_ctx(unsigned long ctxid)
 {
 	unsigned long id = CTX_ARRAY_ID(ctxid);
@@ -387,7 +251,6 @@ int vsi_v4l2_release(struct file *filp)
 {
 	struct vsi_v4l2_ctx *ctx = fh_to_ctx(filp->private_data);
 
-	vsi_v4l2_remove_dbgfs_file(ctx);
 	/*normal streaming end should fall here*/
 	v4l2_klog(LOGLVL_BRIEF, "%s ctx %llx", __func__, ctx->ctxid);
 	vsi_clear_daemonmsg(CTX_ARRAY_ID(ctx->ctxid));
@@ -686,14 +549,12 @@ int vsi_v4l2_bufferdone(struct vsi_v4l2_msg *pmsg)
 	struct vb2_queue *vq = NULL;
 	struct vb2_buffer	*vb;
 	struct vb2_v4l2_buffer *vbuf;
-	struct vsi_vpu_performance_info *info;
 	int ret = 0;
 
 	ctx = get_ctx(ctxid);
 	if (ctx == NULL)
 		return -1;
 
-	info = &ctx->performance;
 	if (isencoder(ctx)) {
 		inbufidx = pmsg->params.enc_params.io_buffer.inbufidx;
 		outbufidx = pmsg->params.enc_params.io_buffer.outbufidx;
@@ -740,14 +601,6 @@ int vsi_v4l2_bufferdone(struct vsi_v4l2_msg *pmsg)
 				set_bit(BUF_FLAG_DONE, &ctx->srcvbufflag[inbufidx]);
 			}
 		}
-
-		info->processed_buf_num++;
-		info->ts_last = ktime_get_raw();
-		if (isdecoder(ctx))
-			info->total_time += pmsg->params.dec_params.io_buffer.process_time;
-		else
-			info->total_time += pmsg->params.enc_params.io_buffer.process_time;
-
 		mutex_unlock(&ctx->ctxlock);
 	}
 	if (outbufidx >= 0 && outbufidx < ctx->output_que.num_buffers) {
@@ -811,12 +664,6 @@ int vsi_v4l2_bufferdone(struct vsi_v4l2_msg *pmsg)
 				}
 				v4l2_klog(LOGLVL_FLOW, "dec output framed %d size = %d", outbufidx, vb->planes[0].bytesused);
 			}
-			if (bytesused[0] > 0) {
-				if (!info->ts_disp_first)
-					info->ts_disp_first = ktime_get_raw();
-				info->ts_disp_last = ktime_get_raw();
-				info->display_frame_num++;
-			}
 			vbuf->sequence = ctx->cap_sequence++;
 			vb2_buffer_done(vb, VB2_BUF_STATE_DONE);
 		} else {
@@ -829,41 +676,6 @@ int vsi_v4l2_bufferdone(struct vsi_v4l2_msg *pmsg)
 out:
 	put_ctx(ctx);
 	return ret;
-}
-
-void vsi_v4l2_reset_performance(struct vsi_v4l2_ctx *ctx)
-{
-	struct vsi_vpu_performance_info *info;
-	u64 fps_dec = 0, fps_dsp = 0, fps_sw = 0;
-	u64 timems;
-	u64 latency;
-	u64 temp;
-
-	if (!ctx)
-		return;
-
-	info = &ctx->performance;
-	if (!info->processed_buf_num)
-		goto exit;
-
-	temp = MSEC_PER_SEC * info->processed_buf_num;
-	timems = (info->ts_last - info->ts_start) / NSEC_PER_MSEC;
-	fps_dec = DIV_ROUND_CLOSEST(temp, timems);
-	if (info->total_time)
-		fps_sw = DIV_ROUND_CLOSEST(temp, info->total_time / NSEC_PER_MSEC);
-	if (info->display_frame_num > 1) {
-		temp = MSEC_PER_SEC * (info->display_frame_num - 1);
-		timems = (info->ts_disp_last - info->ts_disp_first) / NSEC_PER_MSEC;
-		fps_dsp = DIV_ROUND_CLOSEST(temp, timems);
-	}
-	latency = info->ts_disp_first - info->ts_start;
-
-	v4l2_klog(LOGLVL_FLOW,
-		  "[%llx]fps actual: %llu, disp: %llu, ideal: %llu, latency(ms) %llu.%06llu\n",
-		  ctx->ctxid, fps_dec, fps_dsp, fps_sw,
-		  latency / NSEC_PER_MSEC, latency % NSEC_PER_MSEC);
-exit:
-	memset(info, 0, sizeof(*info));
 }
 
 static void vsi_daemonsdevice_release(struct device *dev)
@@ -926,7 +738,6 @@ static int v4l2_probe(struct platform_device *pdev)
 		goto err;
 	}
 	idr_init(&vsi_inst_array);
-	vpu->debugfs = debugfs_create_dir(VSI_V4L2_DEBUGFS_DIR, NULL);
 
 	gvsidev = pdev;
 	mutex_init(&vsi_ctx_array_lock);
@@ -959,20 +770,18 @@ static int v4l2_remove(struct platform_device *pdev)
 	int id;
 	struct vsi_v4l2_device *vpu = platform_get_drvdata(pdev);
 
+	vsi_v4l2_release_dec(vpu->vdec);
+	vsi_v4l2_release_enc(vpu->venc);
+	v4l2_device_unregister(&vpu->v4l2_dev);
+	platform_set_drvdata(pdev, NULL);
+	kfree(vpu);
+
 	idr_for_each_entry(&vsi_inst_array, obj, id) {
 		if (obj) {
 			release_ctx(obj, 0);
 			vsi_v4l2_quitinstance();
 		}
 	}
-
-	debugfs_remove_recursive(vpu->debugfs);
-	vpu->debugfs = NULL;
-	vsi_v4l2_release_dec(vpu->vdec);
-	vsi_v4l2_release_enc(vpu->venc);
-	v4l2_device_unregister(&vpu->v4l2_dev);
-	platform_set_drvdata(pdev, NULL);
-	kfree(vpu);
 
 	device_unregister(vsidaemondev);
 	class_destroy(vsidaemondev->class);

--- a/drivers/mxc/hantro_v4l2/vsi-v4l2.h
+++ b/drivers/mxc/hantro_v4l2/vsi-v4l2.h
@@ -229,7 +229,6 @@ struct v4l2_daemon_enc_buffers {
 	u32 bytesused;	//valid bytes in buffer from user app.
 	s64 timestamp;
 	u32 average_qp;
-	u64 process_time;
 };
 
 struct v4l2_daemon_enc_general_cmd {
@@ -532,8 +531,6 @@ struct v4l2_daemon_dec_buffers {
 
 	s32 no_reordering_decoding;
 	s32 securemode_on;
-
-	u64 process_time;
 };
 
 //stub struct

--- a/drivers/spi/spi-fsl-lpspi.c
+++ b/drivers/spi/spi-fsl-lpspi.c
@@ -151,17 +151,23 @@ static inline int is_imx95_lpspi(struct fsl_lpspi_data *d)
 	return d->devtype_data->devtype == IMX95_LPSPI;
 };
 
-
+/*
+ * ERR051608 fixed or not:
+ * https://www.nxp.com/docs/en/errata/i.MX93_1P87f.pdf
+ */
 static struct fsl_lpspi_devtype_data imx93_lpspi_devtype_data = {
 	.devtype = IMX93_LPSPI,
+	.prescale_max = 1,
 };
 
 static struct fsl_lpspi_devtype_data imx95_lpspi_devtype_data = {
 	.devtype = IMX95_LPSPI,
+	.prescale_max = 7,
 };
 
 static struct fsl_lpspi_devtype_data imx7ulp_lpspi_devtype_data = {
 	.devtype = IMX7ULP_LPSPI,
+	.prescale_max = 7,
 };
 
 /*
@@ -351,10 +357,7 @@ static int fsl_lpspi_set_bitrate(struct fsl_lpspi_data *fsl_lpspi)
 	u8 prescale;
 
 	perclk_rate = clk_get_rate(fsl_lpspi->clk_per);
-	if (!perclk_rate) {
-		dev_err(fsl_lpspi->dev, "per-clk rate was not set\n");
-		return -EINVAL;
-	}
+	prescale_max = fsl_lpspi->devtype_data->prescale_max;
 
 	if (!config.speed_hz) {
 		dev_err(fsl_lpspi->dev,


### PR DESCRIPTION
While testing on our CI we found 3 regressions:

On i.MX 8QM SPI doesn't allow low baudrates. Fixed with completing the a stable merge.
On i.MX 8MP the hantro VPU was not able to decode a video. Fixed with a revert of a downstream NXP commit. I did not dive into what in that performace statistics code failed.

On i.MX 8X we've seen suspend/resume not waking up (CI uses the SoC RTC for wakeup). Reason and fix currently unknown.