### PR TITLE
nvmem: imx-ocotp-fsb-s400: BUG: Fix the word count

### DIFF
--- a/drivers/nvmem/imx-ocotp-fsb-s400.c
+++ b/drivers/nvmem/imx-ocotp-fsb-s400.c
@@ -304,7 +304,8 @@ static int fsb_s400_fuse_write(void *priv, unsigned int offset, void *val, size_
 	if (bytes != 4)
 		return -EINVAL;
 
-	index = offset;
+	/* divide the offset by the word size to get the word count */
+	index = offset / 4;
 
 	mutex_lock(&fuse->lock);
 	ret = ele_write_fuse(fuse->se_dev, index, *buf, false);


### PR DESCRIPTION
Should be backported to [6.6-2.0.x-imx](https://github.com/Freescale/linux-fslc/tree/6.6-2.0.x-imx) as well.

Please add any of these as reviewers:
- ye.li@nxp.com
- sebastien.haezebrouck@nxp.com
- peng.fan@nxp.com

Thanks!