### PR TITLE
tty: vt: conmakehash: Don't mention the full path of the input in output

### DIFF
--- a/drivers/tty/vt/conmakehash.c
+++ b/drivers/tty/vt/conmakehash.c
@@ -76,7 +76,8 @@ static void addpair(int fp, int un)
 int main(int argc, char *argv[])
 {
   FILE *ctbl;
-  char *tblname;
+  const char *tblname, *rel_tblname;
+  const char *abs_srctree;
   char buffer[65536];
   int fontlen;
   int i, nuni, nent;
@@ -100,6 +101,16 @@ int main(int argc, char *argv[])
 	  exit(EX_NOINPUT);
 	}
     }
+
+  abs_srctree = getenv("abs_srctree");
+  if (abs_srctree && !strncmp(abs_srctree, tblname, strlen(abs_srctree)))
+    {
+      rel_tblname = tblname + strlen(abs_srctree);
+      while (*rel_tblname == '/')
+	++rel_tblname;
+    }
+  else
+    rel_tblname = tblname;
 
   /* For now we assume the default font is always 256 characters. */
   fontlen = 256;
@@ -253,7 +264,7 @@ int main(int argc, char *argv[])
 #include <linux/types.h>\n\
 \n\
 u8 dfont_unicount[%d] = \n\
-{\n\t", argv[1], fontlen);
+{\n\t", rel_tblname, fontlen);
 
   for ( i = 0 ; i < fontlen ; i++ )
     {


### PR DESCRIPTION
This change strips $abs_srctree of the input file containing the character mapping table in the generated output. The motivation for this change is Yocto emitting a build warning

        WARNING: linux-lxatac-6.7-r0 do_package_qa: QA Issue: File /usr/src/debug/linux-lxatac/6.7-r0/drivers/tty/vt/consolemap_deftbl.c in package linux-lxatac-src contains reference to TMPDIR

So this change brings us one step closer to make the build result reproducible independent of the build path.


Link: https://lore.kernel.org/r/20240311113017.483101-2-u.kleine-koenig@pengutronix.de