### PR TITLE
nvmem: imx-ocotp-fsb-s400: BUG: Fix the word count

### DIFF
--- a/drivers/nvmem/imx-ocotp-fsb-s400.c
+++ b/drivers/nvmem/imx-ocotp-fsb-s400.c
@@ -304,7 +304,8 @@ static int fsb_s400_fuse_write(void *priv, unsigned int offset, void *val, size_
 	if (bytes != 4)
 		return -EINVAL;
 
-	index = offset;
+	/* divide the offset by the word size to get the word count */
+	index = offset / 4;
 
 	mutex_lock(&fuse->lock);
 	ret = ele_write_fuse(fuse->se_dev, index, *buf, false);


### PR DESCRIPTION
Only a block size of 4 bytes is supported, so divide the offset by 4 to obtain the correct word count, as is done in other drivers such as: imx-ocotp.c

How to reproduce the bug?
e.g. try to write first word of the MAC_ADDR1 on imx93 FUSE_DEV=/sys/bus/nvmem/devices/fsb_s400_fuse0/nvmem OFFSET_MAC=315
dd if=<binfile> of=$FUSE_DEV bs=4 count=1 seek=$OFFSET_MAC conv=notrunc

fsl-se-fw se-fw2: Command Id[214], Status=0x29, Indicator=0xA7 ELE_WRONG_SIZE_FAILURE_IND:0xA7, because the fuse being programmed is not in the SoC fuse map.