### PR TITLE
drivers:clk:imx:clk-imx8mp-audiomix: remove duplicated CLK_GATE_PARENT definition

### DIFF
--- a/drivers/clk/imx/clk-imx8mp-audiomix.c
+++ b/drivers/clk/imx/clk-imx8mp-audiomix.c
@@ -151,15 +151,6 @@ static int shared_count_pdm;
 		reg, width, shift, shcount				\
 	}
 
-#define CLK_GATE_PARENT(gname, cname, pname)						\
-	{								\
-		gname"_cg",						\
-		IMX8MP_CLK_AUDIOMIX_##cname,				\
-		{ .fw_name = pname, .name = pname }, NULL, 1,		\
-		CLKEN0 + 4 * !!(AUDIOMIX_##cname / 32),	\
-		1, AUDIOMIX_##cname % 32			\
-	}
-
 #define CLK_SAIn(n)							\
 	{								\
 		"sai"__stringify(n)"_mclk1_sel",			\


### PR DESCRIPTION
The macro CLK_GATE_PARENT is defined twice.

This causes compiler redefinition warnings.

The first definition, which is overridden by the compiler, is therefore removed.

#708 
