### PR TITLE
drivers: gpu: drm: msm: registers: improve reproducibility

### DIFF
--- a/drivers/gpu/drm/msm/registers/gen_header.py
+++ b/drivers/gpu/drm/msm/registers/gen_header.py
@@ -11,6 +11,7 @@ import collections
 import argparse
 import time
 import datetime
+import re
 
 class Error(Exception):
 	def __init__(self, message):
@@ -877,13 +878,15 @@ The rules-ng-ng source files this header was generated from are:
 """)
 	maxlen = 0
 	for filepath in p.xml_files:
-		maxlen = max(maxlen, len(filepath))
+		new_filepath = re.sub("^.+drivers","drivers",filepath)
+		maxlen = max(maxlen, len(new_filepath))
 	for filepath in p.xml_files:
-		pad = " " * (maxlen - len(filepath))
+		new_filepath = re.sub("^.+drivers","drivers",filepath)
+		pad = " " * (maxlen - len(new_filepath))
 		filesize = str(os.path.getsize(filepath))
 		filesize = " " * (7 - len(filesize)) + filesize
 		filetime = time.ctime(os.path.getmtime(filepath))
-		print("- " + filepath + pad + " (" + filesize + " bytes, from " + filetime + ")")
+		print("- " + new_filepath + pad + " (" + filesize + " bytes, from <stripped>)")
 	if p.copyright_year:
 		current_year = str(datetime.date.today().year)
 		print()


### PR DESCRIPTION
Backport commit [`874746eaa341 ("drivers: gpu: drm: msm: registers: improve reproducibility")`](https://git.yoctoproject.org/linux-yocto/commit/?id=874746eaa341) from `linux-yocto` repository.

Fix-up the generated name in the inner loop, previous patch version used the same last name from the first loop in the second loop that produced the actual output.

Original commit description:
> The files generated by gen_header.py capture the source path to the input files and the date.  While that can be informative, it varies based on where and when the kernel was built as the full path is captured.
> 
> Since all of the files that this tool is run on is under the drivers directory, this modifies the application to strip all of the path before drivers.  Additionally it prints <stripped> instead of the date.
>
> Both changes solve the reproducibility issue.
>
> Upstream-Status: Inappropriate
