### PR TITLE
media: Kconfig: fix double VIDEO_DEV

### DIFF
--- a/drivers/staging/media/imx/Kconfig
+++ b/drivers/staging/media/imx/Kconfig
@@ -4,7 +4,6 @@ config VIDEO_IMX_MEDIA
 	depends on ARCH_MXC || COMPILE_TEST
 	depends on HAS_DMA
 	depends on VIDEO_DEV
-	depends on VIDEO_DEV
 	depends on IMX_IPUV3_CORE
 	select MEDIA_CONTROLLER
 	select V4L2_FWNODE


### PR DESCRIPTION
The VIDEO_IMX_MEDIA dependency of VIDEO_DEV has 2 entries. Remove a duplicate.

Upstream-Status: Pending

Fixes: commit 9958d30f38b96 ("media: Kconfig: cleanup VIDEO_DEV dependencies")

----

This is not a critical commit so I don't plan to bump the recipe right away