### PR TITLE
firmware: se_fw: remove info_list from ro section

### DIFF
--- a/drivers/firmware/imx/se_fw.c
+++ b/drivers/firmware/imx/se_fw.c
@@ -103,7 +103,7 @@ struct seco_soc_info {
 
 static LIST_HEAD(priv_data_list);
 
-static const struct imx_info_list imx8ulp_info = {
+static struct imx_info_list imx8ulp_info = {
 	.num_mu = 1,
 	.soc_id = SOC_ID_OF_IMX8ULP,
 	.board_type = 0,
@@ -138,7 +138,7 @@ static const struct imx_info_list imx8ulp_info = {
 	},
 };
 
-static const struct imx_info_list imx93_info = {
+static struct imx_info_list imx93_info = {
 	.num_mu = 1,
 	.soc_id = SOC_ID_OF_IMX93,
 	.board_type = 0,
@@ -172,7 +172,7 @@ static const struct imx_info_list imx93_info = {
 	},
 };
 
-static const struct imx_info_list imx8dxl_info = {
+static struct imx_info_list imx8dxl_info = {
 	.num_mu = 7,
 	.soc_id = SOC_ID_OF_IMX8DXL,
 	.board_type = 0,
@@ -362,7 +362,7 @@ static const struct imx_info_list imx8dxl_info = {
 	},
 };
 
-static const struct imx_info_list imx95_info = {
+static struct imx_info_list imx95_info = {
 	.num_mu = 4,
 	.soc_id = SOC_ID_OF_IMX95,
 	.board_type = 0,


### PR DESCRIPTION
The change removes the imx_info_list structures from the read-only section.

This avoid the kernel panics that might occur during the driver probe when info_list is being altered.



Fixes: 650987a3574 (" LF-10819: Secure Enclave FW driver: Add IOCTL to get SoC Info")