### PR TITLE
irqchip/imx-irqsteer: remove pm_runtime_set_active function call

### DIFF
--- a/drivers/irqchip/irq-imx-irqsteer.c
+++ b/drivers/irqchip/irq-imx-irqsteer.c
@@ -315,7 +315,6 @@ static int imx_irqsteer_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, data);
 
-	pm_runtime_set_active(&pdev->dev);
 	pm_runtime_enable(&pdev->dev);
 
 	return 0;


### PR DESCRIPTION
This function was introduced by commit 0abb3875e53d ("irqchip/imx-irqsteer: Add runtime PM support") from linux stable v5.15.165, when the merge was done. However, commit 5e46c8d40318 ("MLK-17290-01 irqchip: imx-irqsteer: add runtime pm support") from NXP downstream kernel already adds the same feature.

When the conflict was resolved on the merge of v5.15.165, this function was left behind by mistake, causing the kernel to crash during boot on i.MX8QM and i.MX8X SoCs. Therefore, remove this function to keep the irq-imx-irqsteer driver as it is on the NXP downstream branch and to fix the regression introduced.

Fixes: cf78be207dca ("Merge tag 'v5.15.165' into 5.15-2.2.x-imx")