### PR TITLE
Fix spi-nxp-fspi merge error

### DIFF
--- a/drivers/spi/spi-nxp-fspi.c
+++ b/drivers/spi/spi-nxp-fspi.c
@@ -61,12 +61,6 @@
 
 /* runtime pm timeout */
 #define FSPI_RPM_TIMEOUT 50	/* 50ms */
-/*
- * The driver only uses one single LUT entry, that is updated on
- * each call of exec_op(). Index 0 is preset at boot with a basic
- * read operation, so let's use the last entry (15).
- */
-#define	SEQID_LUT			15
 
 /* Registers used by the driver */
 #define FSPI_MCR0			0x00
@@ -976,15 +970,15 @@ static int nxp_fspi_do_op(struct nxp_fspi *f, const struct spi_mem_op *op)
 	 * address A-1, need to read one more byte to get all
 	 * data needed.
 	 */
-
+	seqid_lut = f->devtype_data->lut_num - 1;
 	if (f->flags & FSPI_DTR_ODD_ADDR)
 		fspi_writel(f, (op->data.nbytes + 1) |
-			 (SEQID_LUT << FSPI_IPCR1_SEQID_SHIFT) |
+			 (seqid_lut << FSPI_IPCR1_SEQID_SHIFT) |
 			 (seqnum << FSPI_IPCR1_SEQNUM_SHIFT),
 			 base + FSPI_IPCR1);
 	else
 		fspi_writel(f, op->data.nbytes |
-			 (SEQID_LUT << FSPI_IPCR1_SEQID_SHIFT) |
+			 (seqid_lut << FSPI_IPCR1_SEQID_SHIFT) |
 			 (seqnum << FSPI_IPCR1_SEQNUM_SHIFT),
 			 base + FSPI_IPCR1);
 


### PR DESCRIPTION
The commit:
spi: fspi: involve lut_num for struct nxp_fspi_devtype_data 45f690fae4736a15bf938356820c3369b575e018

introduced SoC specific LUT number, which was partially reverted with merge:
Merge tag 'v6.6.54' into 6.6-2.2.x-imx
c930b7842cfd5ccbb315735a35aa2011be20e5f7

This leads to a build time warning;
warning: unused variable 'seqid_lut' [-Wunused-variable]

and spi read errors during runtime.
We use the new LUT number version, as is it also used in mainline.