### PR TITLE
imx8mp-olimex.dts: CSI GPIO pins

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-olimex.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-olimex.dts
@@ -977,21 +977,15 @@
 		>;
 	};
 
-	pinctrl_csi0_pwn: csi0_pwn_grp {
+	pinctrl_csi0_en: csi0_en_grp {
 		fsl,pins = <
-			MX8MP_IOMUXC_SD1_STROBE__GPIO2_IO11	0x10
+			MX8MP_IOMUXC_GPIO1_IO05__GPIO1_IO05		0x10
 		>;
 	};
 
-	pinctrl_csi0_rst: csi0_rst_grp {
+	pinctrl_csi1_en: csi1_en_grp {
 		fsl,pins = <
 			MX8MP_IOMUXC_GPIO1_IO06__GPIO1_IO06		0x10
-		>;
-	};
-
-	pinctrl_csi_mclk: csi_mclk_grp {
-		fsl,pins = <
-			MX8MP_IOMUXC_GPIO1_IO15__CCM_CLKO2	0x50
 		>;
 	};
 };


### PR DESCRIPTION
Device tree pinmux entries for the CSI ports on Olimex IMX8MP SoM. 

PR to Olimex: https://github.com/OLIMEX/buildroot-imx/pull/1