### PR TITLE
Fix scmi cpufreq not working after v6.6.95 merge

### DIFF
--- a/drivers/firmware/arm_scmi/bus.c
+++ b/drivers/firmware/arm_scmi/bus.c
@@ -373,8 +373,7 @@ __scmi_device_create(struct device_node *np, struct device *parent,
 	scmi_dev->id = id;
 	scmi_dev->protocol_id = protocol;
 	scmi_dev->dev.parent = parent;
-	if ((protocol != SCMI_PROTOCOL_PERF) || strcmp(name, "cpufreq"))
-		device_set_node(&scmi_dev->dev, of_fwnode_handle(np));
+	device_set_node(&scmi_dev->dev, of_fwnode_handle(np));
 	scmi_dev->dev.bus = &scmi_bus_type;
 	scmi_dev->dev.release = scmi_device_release;
 	dev_set_name(&scmi_dev->dev, "scmi_dev.%d", id);


### PR DESCRIPTION
The commit 762325441e3a ("cpufreq: scmi: Skip SCMI devices that aren't used by the CPUs") from v6.6.95 is not compatible with 0dc334f2dd3e ("LF-12944 firmware: arm_scmi: bus: bypass set fwnode for scmi cpufreq") commit and prevent scmi cpufreq driver initialization.
Fix the problem by reverting the nxp downstream patch