### PR TITLE
fix mxc_isi_m2m_resume after integration of v6.6.114

### DIFF
--- a/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
+++ b/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
@@ -733,7 +733,7 @@ int mxc_isi_m2m_resume(struct mxc_isi_pipe *pipe)
 	mxc_isi_channel_get(pipe);
 
 	if (ctx->chained)
-		mxc_isi_channel_chain(pipe, false);
+		mxc_isi_channel_chain(pipe);
 
 	m2m->last_ctx = NULL;
 	v4l2_m2m_resume(m2m->m2m_dev);


### PR DESCRIPTION
Since commit 211728b9b282 ("media: nxp: imx8-isi: Drop unused argument to mxc_isi_channel_chain()") has only parameter.

Fixes: 0af8cf59fa6e ("Merge tag 'v6.6.114' into 6.6-2.2.x-imx")