### PR TITLE
Fix build error in imx8-isi driver

### DIFF
--- a/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
+++ b/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
@@ -733,7 +733,7 @@ int mxc_isi_m2m_resume(struct mxc_isi_pipe *pipe)
 	mxc_isi_channel_get(pipe);
 
 	if (ctx->chained)
-		mxc_isi_channel_chain(pipe, false);
+		mxc_isi_channel_chain(pipe);
 
 	m2m->last_ctx = NULL;
 	v4l2_m2m_resume(m2m->m2m_dev);


### PR DESCRIPTION
After merging the latest stable release, builds fail for configurations with the ISI M2M driver enabled.

The upstream commit 211728b9b282 ("media: nxp: imx8-isi: Drop unused argument to mxc_isi_channel_chain()") that came in through stable removed the second argument from `mxc_isi_channel_chain()` but left one call unconverted in `mxc_isi_m2m_resume()`:

```
drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c:736:17: error: too many arguments to function 'mxc_isi_channel_chain'
  736 |                 mxc_isi_channel_chain(pipe, false);
      |                 ^~~~~~~~~~~~~~~~~~~~~
In file included from drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c:35:
drivers/media/platform/nxp/imx8-isi/imx8-isi-core.h:385:5: note: declared here
  385 | int mxc_isi_channel_chain(struct mxc_isi_pipe *pipe);
```

This change completes the API conversion by removing the unused argument from the remaining call.

Verified successful compilation on:
- `imx_v8_defconfig`
- `imx_v6_v7_defconfig`