### PR TITLE
spi: nxp-fspi: Add per_op_freq to quirks mem_caps

### DIFF
--- a/drivers/spi/spi-nxp-fspi.c
+++ b/drivers/spi/spi-nxp-fspi.c
@@ -1312,6 +1312,7 @@ static const struct spi_controller_mem_caps nxp_fspi_mem_caps = {
 
 static const struct spi_controller_mem_caps nxp_fspi_mem_caps_quirks = {
 	.dtr = false,
+	.per_op_freq = true,
 };
 
 static int nxp_fspi_probe(struct platform_device *pdev)


### PR DESCRIPTION
Fix missing per_op_freq capability in NXP FSPI quirks structure after 6.6.119 merge.

Changes:
- Add per_op_freq = true to nxp_fspi_mem_caps_quirks to match the main capability structure

This ensures devices using the quirks path also benefit from per-operation frequency switching.
