### PR TITLE
 Merge nxp-imx/linux-imx release lf-6.6.52-2.2.2

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mq.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mq.dtsi
@@ -728,7 +728,7 @@
 							 <&clk IMX8MQ_AUDIO_PLL2>,
 							 <0>,
 						         <0>,
-							 <&clk IMX8MQ_SYS1_PLL_266M>;
+							 <&clk IMX8MQ_SYS1_PLL_133M>;
 			};
 
 			src: reset-controller@30390000 {

--- a/arch/arm64/boot/dts/freescale/imx95-19x19-verdin.dts
+++ b/arch/arm64/boot/dts/freescale/imx95-19x19-verdin.dts
@@ -45,6 +45,7 @@
 	/delete-node/ sound-wm8962;
 	/delete-node/ pca9632;
 	/delete-node/ i2c3_gpio_expander_20;
+	/delete-node/ pwm-fan;
 
 	sound-wm8904 {
 		compatible = "fsl,imx-audio-wm8904";
@@ -245,6 +246,22 @@
 &lpuart5 {
 	bluetooth {
 		fw-init-baudrate = <115200>;
+	};
+};
+
+&thermal_zones {
+	a55 {
+		trips {
+			/delete-node/ trip2;
+			/delete-node/ trip3;
+			/delete-node/ trip4;
+		};
+
+		cooling-maps {
+			/delete-node/ map1;
+			/delete-node/ map2;
+			/delete-node/ map3;
+		};
 	};
 };
 

--- a/drivers/gpu/drm/bridge/lontium-lt8912b.c
+++ b/drivers/gpu/drm/bridge/lontium-lt8912b.c
@@ -500,6 +500,7 @@ static int lt8912_attach_dsi(struct lt8912 *lt)
 
 	dsi->mode_flags = MIPI_DSI_MODE_VIDEO |
 			  MIPI_DSI_MODE_LPM |
+			  MIPI_DSI_MODE_VIDEO_NO_HFP |
 			  MIPI_DSI_MODE_NO_EOT_PACKET;
 
 	ret = devm_mipi_dsi_attach(dev, dsi);

--- a/drivers/gpu/drm/bridge/lontium-lt8912b.c
+++ b/drivers/gpu/drm/bridge/lontium-lt8912b.c
@@ -411,22 +411,6 @@ static const struct drm_connector_funcs lt8912_connector_funcs = {
 	.atomic_destroy_state = drm_atomic_helper_connector_destroy_state,
 };
 
-static enum drm_mode_status
-lt8912_connector_mode_valid(struct drm_connector *connector,
-			    struct drm_display_mode *mode)
-{
-	if (mode->clock > 150000)
-		return MODE_CLOCK_HIGH;
-
-	if (mode->hdisplay > 1920)
-		return MODE_BAD_HVALUE;
-
-	if (mode->vdisplay > 1080)
-		return MODE_BAD_VVALUE;
-
-	return MODE_OK;
-}
-
 static int lt8912_connector_get_modes(struct drm_connector *connector)
 {
 	const struct drm_edid *drm_edid;
@@ -452,7 +436,6 @@ static int lt8912_connector_get_modes(struct drm_connector *connector)
 
 static const struct drm_connector_helper_funcs lt8912_connector_helper_funcs = {
 	.get_modes = lt8912_connector_get_modes,
-	.mode_valid = lt8912_connector_mode_valid,
 };
 
 static void lt8912_bridge_mode_set(struct drm_bridge *bridge,
@@ -595,6 +578,23 @@ static void lt8912_bridge_detach(struct drm_bridge *bridge)
 		drm_bridge_hpd_disable(lt->hdmi_port);
 }
 
+static enum drm_mode_status
+lt8912_bridge_mode_valid(struct drm_bridge *bridge,
+			 const struct drm_display_info *info,
+			 const struct drm_display_mode *mode)
+{
+	if (mode->clock > 150000)
+		return MODE_CLOCK_HIGH;
+
+	if (mode->hdisplay > 1920)
+		return MODE_BAD_HVALUE;
+
+	if (mode->vdisplay > 1080)
+		return MODE_BAD_VVALUE;
+
+	return MODE_OK;
+}
+
 static enum drm_connector_status
 lt8912_bridge_detect(struct drm_bridge *bridge)
 {
@@ -625,6 +625,7 @@ static struct edid *lt8912_bridge_get_edid(struct drm_bridge *bridge,
 static const struct drm_bridge_funcs lt8912_bridge_funcs = {
 	.attach = lt8912_bridge_attach,
 	.detach = lt8912_bridge_detach,
+	.mode_valid = lt8912_bridge_mode_valid,
 	.mode_set = lt8912_bridge_mode_set,
 	.enable = lt8912_bridge_enable,
 	.detect = lt8912_bridge_detect,

--- a/drivers/gpu/drm/bridge/synopsys/dw-mipi-dsi.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-mipi-dsi.c
@@ -85,7 +85,12 @@
 #define ENABLE_CMD_MODE			BIT(0)
 
 #define DSI_VID_MODE_CFG		0x38
-#define ENABLE_LOW_POWER		(0x3f << 8)
+#define ENABLE_LOW_POWER_HFP		(0x20 << 8)
+#define ENABLE_LOW_POWER_HBP		(0x10 << 8)
+#define ENABLE_LOW_POWER_VACT		(0x8 << 8)
+#define ENABLE_LOW_POWER_VFP		(0x4 << 8)
+#define ENABLE_LOW_POWER_VBP		(0x2 << 8)
+#define ENABLE_LOW_POWER_VSA		(0x1 << 8)
 #define ENABLE_LOW_POWER_MASK		(0x3f << 8)
 #define VID_MODE_TYPE_NON_BURST_SYNC_PULSES	0x0
 #define VID_MODE_TYPE_NON_BURST_SYNC_EVENTS	0x1
@@ -593,14 +598,21 @@ static void dw_mipi_dsi_video_mode_config(struct dw_mipi_dsi *dsi)
 	 * enabling low power is panel-dependent, we should use the
 	 * panel configuration here...
 	 */
-	val = ENABLE_LOW_POWER;
+	val = ENABLE_LOW_POWER_VACT | ENABLE_LOW_POWER_VFP | ENABLE_LOW_POWER_VSA |
+	      ENABLE_LOW_POWER_VBP;
 
 	if (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_BURST)
-		val |= VID_MODE_TYPE_BURST;
-	else if (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_SYNC_PULSE)
-		val |= VID_MODE_TYPE_NON_BURST_SYNC_PULSES;
-	else
+		val |= VID_MODE_TYPE_BURST | ENABLE_LOW_POWER_HFP | ENABLE_LOW_POWER_HBP;
+	else if (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_SYNC_PULSE) {
+		val |= VID_MODE_TYPE_NON_BURST_SYNC_PULSES | ENABLE_LOW_POWER_HFP |
+		       ENABLE_LOW_POWER_HBP;
+	} else {
 		val |= VID_MODE_TYPE_NON_BURST_SYNC_EVENTS;
+		if (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_NO_HFP)
+			val |= ENABLE_LOW_POWER_HFP;
+		if (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_NO_HBP)
+			val |= ENABLE_LOW_POWER_HBP;
+	}
 
 #ifdef CONFIG_DEBUG_FS
 	if (dsi->vpg_defs.vpg) {
@@ -809,6 +821,24 @@ static void dw_mipi_dsi_line_timer_config(struct dw_mipi_dsi *dsi,
 
 	lbcc = dw_mipi_dsi_get_hcomponent_lbcc(dsi, mode, hsa);
 	dsi_write(dsi, DSI_VID_HSA_TIME, lbcc);
+
+	/*
+	 * This timing fixup allows the HFP to go into low power mode for
+	 * 720p60. There is a line size mismatch between DPI and MIPI
+	 * domain for four lanes using 24 bits per pixel. Forcing the HFP
+	 * into low power mode allows the line timer to be reset, thus
+	 * preserving the DPI timing. Without this adjustment, the MIPI
+	 * domain timing drifts from the DPI domain corrupting the video.
+	 * Most other MIPI controllers have workarounds for this mode's
+	 * behavior.
+	 */
+	if (mode->htotal == 1650 && mode->vtotal == 750 &&
+	    dsi->lanes == 4 && dsi->format == MIPI_DSI_FMT_RGB888 &&
+	    (dsi->mode_flags & MIPI_DSI_MODE_VIDEO_NO_HFP) &&
+	    !(dsi->mode_flags & MIPI_DSI_MODE_VIDEO_NO_HBP) &&
+	    !(dsi->mode_flags & MIPI_DSI_MODE_VIDEO_SYNC_PULSE) &&
+	    !(dsi->mode_flags & MIPI_DSI_MODE_VIDEO_BURST))
+		hbp = hbp - min(32, hbp);
 
 	lbcc = dw_mipi_dsi_get_hcomponent_lbcc(dsi, mode, hbp);
 	dsi_write(dsi, DSI_VID_HBP_TIME, lbcc);

--- a/drivers/mxc/gpu-viv/hal/kernel/gc_hal_kernel_video_memory.c
+++ b/drivers/mxc/gpu-viv/hal/kernel/gc_hal_kernel_video_memory.c
@@ -893,6 +893,11 @@ gckVIDMEM_AllocateLinear(IN gckKERNEL Kernel, IN gckVIDMEM Memory,
         }
     }
 #endif
+    if (Alignment > 0) {
+        /* Ensure the size is aligned */
+        Bytes = gcmALIGN(Bytes, Alignment);
+    }
+
     if (Bytes > Memory->freeBytes) {
         /* Not enough memory. */
         status = gcvSTATUS_OUT_OF_MEMORY;
@@ -951,9 +956,6 @@ gckVIDMEM_AllocateLinear(IN gckKERNEL Kernel, IN gckVIDMEM Memory,
 
     /* Do we have an alignment? */
     if (alignment > 0) {
-        /* Ensure the size is aligned */
-        Bytes = gcmALIGN(Bytes, alignment);
-
         /* Split the node so it is aligned. */
         if (_Split(Memory->os, node, alignment)) {
             /* Successful split, move to aligned node. */


### PR DESCRIPTION
Brings in NXP lf-6.6.52-2.2.2 updates, including clock fixes, MIPI DSI timing improvements, and GPU memory allocation fixes.

```
$ git log --oneline  lf-6.6.52-2.2.1...lf-6.6.52-2.2.2
5a0a5e71d2bd (tag: lf-6.6.52-2.2.2, linux-imx/lf-6.6.y) LF-16351 arm64: dts: imx95-19x19-verdin: remove pwm fan
6ed0fd23b84d LF-13727 [#ccc] fix Bytes alignment issue of gpu video memory node
8555a7698a46 LF-15511: arm64: dts: imx8mq: set NAND_USDHC_BUS_CLK_ROOT source clock to SYSTEM_PLL1_DIV6
c1943c45a497 drm/bridge: lontium-lt8912b: Validate mode in drm_bridge_funcs::mode_valid()
fd990e4c7900 LF-14666-2: drm/bridge: synopsys: dw-mipi-dsi: Implement fixup for 720p60
5db35221420d LF-14666-1: drm/bridge: lontium-lt8912b: Add mode flag for MIPI_DSI_MODE_NO_HFP
```