### PR TITLE
can: flexcan: fix disable transceiver during system PM

### DIFF
--- a/drivers/net/can/flexcan/flexcan-core.c
+++ b/drivers/net/can/flexcan/flexcan-core.c
@@ -2297,7 +2297,6 @@ static int __maybe_unused flexcan_suspend(struct device *device)
 				return err;
 
 			flexcan_chip_interrupts_disable(dev);
-			flexcan_transceiver_disable(priv);
 
 			err = flexcan_transceiver_disable(priv);
 			if (err)
@@ -2332,9 +2331,6 @@ static int __maybe_unused flexcan_resume(struct device *device)
 				return err;
 		} else {
 			err = pinctrl_pm_select_default_state(device);
-			if (err)
-				return err;
-			err = flexcan_transceiver_enable(priv);
 			if (err)
 				return err;
 


### PR DESCRIPTION
Both downstream and stable added a commit to disable the CAN transceiver during system suspend/resume, i.e. disabling/enabling the regulator for the transceiver supply.
commit b9beff0c3267 ("LF-14560 can: flexcan: disable transceiver during system PM")
commit dc55ba5f6dd5 ("can: flexcan: disable transceiver during system PM")

During the merge of stable into downstream the calls to regulator_disable/enable were added from both branches resulting in calling disable/enable twice which ends in an -EIO return value.

Delete the extra calls to disable/enable.

Prevents:
| ------------[ cut here ]------------
| unbalanced disables for can2_supply
| WARNING: CPU: 3 PID: 752 at drivers/regulator/core.c:3000 _regulator_disable+0x130/0x25c

Fixes: 458f081034d6 ("Merge tag 'v6.12.21' into lf-6.12.20-2.0.0")