### PR TITLE
Fix for integration of v6.12.55

### DIFF
--- a/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
+++ b/drivers/media/platform/nxp/imx8-isi/imx8-isi-m2m.c
@@ -736,7 +736,7 @@ int mxc_isi_m2m_resume(struct mxc_isi_pipe *pipe)
 	mxc_isi_channel_get(pipe);
 
 	if (ctx->chained)
-		mxc_isi_channel_chain(pipe, false);
+		mxc_isi_channel_chain(pipe);
 
 	m2m->last_ctx = NULL;
 	v4l2_m2m_resume(m2m->m2m_dev);


### PR DESCRIPTION
Second parameter of mxc_isi_channel_chain was removed in upstream. Fix in mxc_isi_m2m_resume which is only present in downstream fork.

Fixes 9a8f34672049 ("Merge tag 'v6.12.55' into 6.12-2.0.x-imx")