### PR TITLE
arm64: dts: imx8mp: Deterministic SPI order

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mp.dtsi
@@ -41,6 +41,11 @@
 		serial2 = &uart3;
 		serial3 = &uart4;
 		spi0 = &flexspi;
+		spi1 = &ecspi1;
+		spi2 = &ecspi2;
+		spi3 = &ecspi3;
+		can0 = &flexcan1;
+		can1 = &flexcan2;
 		isi0 = &isi_0;
 		isi1 = &isi_1;
 		csi0 = &mipi_csi_0;


### PR DESCRIPTION
Lack of SPI aliases caused the ecSPI interfaces to be assigned at random due to parallel probing which messes up spidev usage that relies on a predictable bus numbering. CAN aliases added for good measure, they didn't seem to exhibit random assignment in the wild.

Fixes this behavior:
```
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi1/device -> ../../../30820000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi2/device -> ../../../30830000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi3/device -> ../../../30840000.spi
root@imx8mp:~# reboot
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi1/device -> ../../../30840000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi2/device -> ../../../30820000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:22 /sys/class/spi_master/spi3/device -> ../../../30830000.spi
root@imx8mp:~# reboot
root@imx8mp:~# ls /sys/class/spi_master/spi*/device -l
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi1/device -> ../../../30830000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi2/device -> ../../../30840000.spi
lrwxrwxrwx 1 root root 0 Jan  8 19:26 /sys/class/spi_master/spi3/device -> ../../../30820000.spi
```

Making the PR against the branch I use, please let meknow if I should target some other branch too.
