### PR TITLE
Fix build failure in imx8qm-mek device tree

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8qm-mek.dts
+++ b/arch/arm64/boot/dts/freescale/imx8qm-mek.dts
@@ -187,7 +187,6 @@
 		regulator-min-microvolt = <3000000>;
 		regulator-max-microvolt = <3000000>;
 		gpio = <&lsio_gpio4 7 GPIO_ACTIVE_HIGH>;
-		off-on-delay-us = <4800>;
 		enable-active-high;
 		off-on-delay-us = <4800>;
 	};


### PR DESCRIPTION
A property duplication was introduced during the procedure for the 6.6.129 stable merge, causing the device tree build to fail.

Remove the existing property and keep the one introduced by commit 837fe3df68601 ("arm64: dts: add off-on-delay-us for usdhc2 regulator")

This went unnoticed before because there were no merge conflicts and device trees not related to Toradex were not built during previous testing.