### PR TITLE
6.12-2.2.x-imx: firmware: imx: ele: read_common_fuse() resp-buf-sz handling

### DIFF
--- a/drivers/firmware/imx/ele_base_msg.c
+++ b/drivers/firmware/imx/ele_base_msg.c
@@ -415,8 +415,9 @@ int read_common_fuse(struct se_if_priv *priv,
 {
 	struct se_api_msg *tx_msg __free(kfree) = NULL;
 	struct se_api_msg *rx_msg __free(kfree) = NULL;
-	int rx_msg_sz = ELE_READ_FUSE_RSP_MSG_SZ;
+	int rx_msg_sz = ELE_READ_FUSE_RSP_MSG_SZ_CRC;
 	int ret = 0;
+	u32 soc_id;
 
 	if (!priv) {
 		ret = -EINVAL;
@@ -429,8 +430,23 @@ int read_common_fuse(struct se_if_priv *priv,
 		goto exit;
 	}
 
-	if (fuse_id == OTP_UNIQ_ID)
+	if ((get_ele_fw_vers_word() & ELE_FW_VERSION_MASK) < ELE_FW_VERSION_2_0_6) {
+		rx_msg_sz = ELE_READ_FUSE_RSP_MSG_SZ;
+	/* Firmware version >= 2.0.6 */
+	} else {
+		soc_id = get_se_soc_id(priv);
+
+		/* i.MX8ULP/93/91 platforms */
+		if (soc_id == SOC_ID_OF_IMX93 ||
+		    soc_id == SOC_ID_OF_IMX91 ||
+		    soc_id == SOC_ID_OF_IMX8ULP)
+			rx_msg_sz = ELE_READ_FUSE_RSP_MSG_SZ;
+	}
+
+	/* OTP_UNIQ_ID is only used on i.MX8ULP platform */
+	if (fuse_id == OTP_UNIQ_ID && soc_id == SOC_ID_OF_IMX8ULP) {
 		rx_msg_sz = ELE_READ_FUSE_OTP_UNQ_ID_RSP_MSG_SZ;
+	}
 
 	rx_msg = kzalloc(rx_msg_sz, GFP_KERNEL);
 	if (!rx_msg) {

--- a/drivers/firmware/imx/ele_base_msg.h
+++ b/drivers/firmware/imx/ele_base_msg.h
@@ -103,6 +103,7 @@ struct ele_dev_info {
 #define ELE_READ_FUSE_REQ		0x97
 #define ELE_READ_FUSE_REQ_MSG_SZ	0x08
 #define ELE_READ_FUSE_RSP_MSG_SZ	0x0C
+#define ELE_READ_FUSE_RSP_MSG_SZ_CRC	0x10
 #define ELE_READ_FUSE_OTP_UNQ_ID_RSP_MSG_SZ \
 					0x1C
 
@@ -123,6 +124,10 @@ struct ele_dev_info {
 #define ELE_GET_FW_VERSION_REQ		0x9d
 #define ELE_GET_FW_VERSION_REQ_SZ	0x04
 #define ELE_GET_FW_VERSION_RSP_SZ	0x10
+
+#define ELE_FW_VERSION_MASK		0xFFFFFF
+#define ELE_FW_VERSION_2_0_6		0x020006
+u32 get_ele_fw_vers_word(void);
 
 int ele_get_info(struct se_if_priv *priv, struct ele_dev_info *s_info);
 int ele_fetch_soc_info(struct se_if_priv *priv, void *data);

--- a/drivers/firmware/imx/se_ctrl.c
+++ b/drivers/firmware/imx/se_ctrl.c
@@ -681,6 +681,17 @@ static bool runtime_fw_status(struct se_if_priv *priv)
 
 	return fw_prsnt_n_running;
 }
+
+/**
+ * get_ele_fw_vers_word() - Get ELE firmware version word
+ *
+ * Return: Firmware version word on success, 0 on failure.
+ */
+u32 get_ele_fw_vers_word(void)
+{
+	return var_se_info.fw_vers_word;
+}
+
 /*
  * get_se_soc_id() - to fetch the soc_id of the platform
  *

--- a/include/linux/firmware/imx/se_api.h
+++ b/include/linux/firmware/imx/se_api.h
@@ -13,6 +13,8 @@
 #define SOC_ID_OF_IMX8QM		0x1
 #define SOC_ID_OF_IMX8QXP		0x2
 #define SOC_ID_OF_IMX93			0x9300
+#define SOC_ID_OF_IMX91			0x9100
+#define SOC_ID_OF_IMX94			0x9430
 #define SOC_ID_OF_IMX95			0x9500
 #define SOC_ID_OF_IMX94			0x9430
 


### PR DESCRIPTION
Update read_common_fuse() to select the appropriate response buffer size based on the ELE firmware version.

Newer firmware versions (>= 2.0.6) return an extended response that may include additional fields (e.g. CRC), requiring a larger buffer size. Older firmware versions continue to use the legacy response format.

Use the ELE firmware version API to detect the running firmware and dynamically adapt the response size to ensure correct parsing of fuse data across firmware versions.

Without this change, systems running newer firmware may experience incorrect response parsing or truncated data when reading fuses.

Add a helper function get_ele_fw_vers_word() to retrieve the ELE firmware version word.